### PR TITLE
fix: potential fix for "too large payload" error

### DIFF
--- a/src/modules/cvs/components/preview/preview.module.scss
+++ b/src/modules/cvs/components/preview/preview.module.scss
@@ -4,22 +4,32 @@
     font-family: Roboto, Helvetica, Arial, sans-serif;
 }
 
+.preview_content {
+    display: flex;
+    gap: 40px;
+    flex-direction: column;
+}
+
 .preview_basic_info {
+    display: flex;
     font-size: clamp(0.8rem, 5vw, 1.2rem);
     page-break-after: always;
 }
 
 .preview_left_col {
+    display: flex;
     border-right: 1px solid #c63031;
     width: 12rem;
     flex-shrink: 0;
 }
 
 .preview_right_col {
+    display: flex;
     padding-left: 30px;
 }
 
 .preview_col {
+    display: flex;
     padding-right: 30px;
     gap: 20px;
 }
@@ -34,11 +44,13 @@
 }
 
 .project_wrapper {
+    display: flex;
     margin-bottom: 25px;
     font-size: clamp(0.8rem, 5vw, 1.2rem);
 }
 
 .project_left_col {
+    display: flex;
     padding-top: 20px;
     width: 20rem;
     flex-shrink: 0;
@@ -47,6 +59,7 @@
 }
 
 .project_right_col {
+    display: flex;
     padding-top: 20px;
     padding-left: 2rem;
     gap: 20px;

--- a/src/modules/cvs/components/preview/preview.tsx
+++ b/src/modules/cvs/components/preview/preview.tsx
@@ -38,7 +38,11 @@ const Preview = ({ cvId }: PreviewProps) => {
         void exportPdf({
             variables: {
                 pdf: {
-                    html: prepareHtml(ref.current),
+                    html: prepareHtml(ref.current, [
+                        styles.preview,
+                        `.${styles.preview_content}`,
+                        "body",
+                    ]),
                     margin: {
                         top: "12mm",
                         bottom: "12mm",
@@ -52,7 +56,7 @@ const Preview = ({ cvId }: PreviewProps) => {
 
     return (
         <Flex className={styles.preview}>
-            <Flex vertical gap={40} ref={ref}>
+            <Flex className={styles.preview_content} ref={ref}>
                 <Flex justify={"space-between"} align={"center"}>
                     <UserInfoBlock userId={userId} />
                     <Button

--- a/src/modules/cvs/components/preview/preview.tsx
+++ b/src/modules/cvs/components/preview/preview.tsx
@@ -2,6 +2,7 @@ import { Button, Flex } from "antd";
 import classNames from "classnames";
 import { useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { Navigate } from "react-router-dom";
 import { FullsizeLoader } from "@/components/fullsize-loader";
 import { useCvById } from "@/modules/cvs/api";
 import { usePdfExport } from "@/modules/cvs/api/export-pdf-mutation.ts";
@@ -9,6 +10,7 @@ import { DomainBlock } from "@/modules/cvs/components/preview/domain-block";
 import { ProjectsBlock } from "@/modules/cvs/components/preview/projects-block";
 import { UserInfoBlock } from "@/modules/cvs/components/preview/user-info-block";
 import { prepareHtml } from "@/modules/cvs/helpers/prepare-html";
+import { routes } from "@/router";
 import { LanguagesBlock } from "./languages-block";
 import styles from "./preview.module.scss";
 import { SkillsInfoBlock } from "./skills-info-block";
@@ -26,9 +28,11 @@ const Preview = ({ cvId }: PreviewProps) => {
 
     const { data: cvData, loading: cvLoading } = useCvById(cvId);
     const [exportPdf, { loading: loadingPdf }] = usePdfExport(cvData?.cv.name);
-    const userId = cvData?.cv.user.id;
+    const userId = cvData?.cv?.user?.id;
 
-    if (cvLoading || !cvData || !userId) return <FullsizeLoader />;
+    if (!userId) return <Navigate to={routes.cvs.root} />;
+
+    if (cvLoading && !cvData) return <FullsizeLoader />;
 
     const handleExportButtonClick = () => {
         if (!ref.current) {
@@ -38,11 +42,7 @@ const Preview = ({ cvId }: PreviewProps) => {
         void exportPdf({
             variables: {
                 pdf: {
-                    html: prepareHtml(ref.current, [
-                        styles.preview,
-                        `.${styles.preview_content}`,
-                        "body",
-                    ]),
+                    html: prepareHtml(ref.current, ["body"]),
                     margin: {
                         top: "12mm",
                         bottom: "12mm",

--- a/src/modules/cvs/helpers/extract-classes.ts
+++ b/src/modules/cvs/helpers/extract-classes.ts
@@ -1,0 +1,21 @@
+const recursiveHelper = (elem: HTMLElement, classList: string[]) => {
+    classList.push(...elem.classList);
+
+    if (elem.hasChildNodes()) {
+        for (const childNode of elem.children) {
+            recursiveHelper(childNode as HTMLElement, classList);
+        }
+    }
+};
+
+export const extractClasses = (elem: HTMLElement) => {
+    const res = [...elem.classList];
+
+    if (elem.hasChildNodes()) {
+        for (const childNode of elem.children) {
+            recursiveHelper(childNode as HTMLElement, res);
+        }
+    }
+
+    return [...new Set(res)];
+};

--- a/src/modules/cvs/helpers/prepare-html.ts
+++ b/src/modules/cvs/helpers/prepare-html.ts
@@ -6,7 +6,7 @@ const prepareStyles = (
 
     const neededSelectors = [
         ...new Set(
-            [...content.innerHTML.matchAll(/class=["']([a-zA-Z0-9_\-\s]+)["']/gm)]
+            [...content.outerHTML.matchAll(/class=["']([a-zA-Z0-9_\-\s]+)["']/gm)]
                 .map((item) => {
                     return item[1].split(" ");
                 })

--- a/src/modules/cvs/helpers/prepare-html.ts
+++ b/src/modules/cvs/helpers/prepare-html.ts
@@ -1,3 +1,5 @@
+import { extractClasses } from "./extract-classes";
+
 const prepareStyles = (
     content: HTMLElement,
     additionalStyleSelectors: string[]
@@ -6,11 +8,7 @@ const prepareStyles = (
 
     const neededSelectors = [
         ...new Set(
-            [...content.outerHTML.matchAll(/class=["']([a-zA-Z0-9_\-\s]+)["']/gm)]
-                .map((item) => {
-                    return item[1].split(" ");
-                })
-                .flat()
+            extractClasses(content)
                 .filter((item) => !item.includes("css-dev-only"))
                 .concat(additionalStyleSelectors)
         ),

--- a/src/modules/cvs/helpers/prepare-html.ts
+++ b/src/modules/cvs/helpers/prepare-html.ts
@@ -21,12 +21,7 @@ const prepareStyles = (
             if (ownerNode instanceof HTMLStyleElement) {
                 const newStyle = document.createElement("style");
                 newStyle.innerHTML = Array.from(styleSheet.cssRules)
-                    .filter((rule) => {
-                        for (const selector of neededSelectors) {
-                            if (rule.cssText.includes(selector)) return true;
-                        }
-                        return false;
-                    })
+                    .filter((rule) => neededSelectors.some((sel) => rule.cssText.includes(sel)))
                     .map((cssRule) =>
                         cssRule.cssText.replace(/:where\(\.css-dev-only[a-zA-Z0-9-]+\)/g, "")
                     )


### PR DESCRIPTION
Potential fix for payload becoming too large (mostly because of sh*tload of exported (and often unnecessary/totally unrelated) css rules) for the back end to handle. This PR makes it so that only the rules that might affect "preview" are exported & applied

To reproduce the issue while on `master`:
- visit as many pages as you can before export (so that "lazy-loading" could load in some more css rules)
- try to export some CV & enjoy your errors

& this doesn't seem to happen if the "preview" page is your first one